### PR TITLE
Fixing link for Mozilla Developer Guide

### DIFF
--- a/open-source-projects.md
+++ b/open-source-projects.md
@@ -427,7 +427,7 @@ Languages/Tech:
 
 ### Mozilla
 
-* [Developer Guide](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Introduction]
+* [Developer Guide](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Introduction)
 
 Languages/Tech:
 


### PR DESCRIPTION
Just a small fix in the markup.
