### PR TITLE
Fixing link for "Open Source for Women."

### DIFF
--- a/open-source-projects.md
+++ b/open-source-projects.md
@@ -8,7 +8,7 @@
 
 * [OpenHatch](http://openhatch.org/) - [Bitesized](https://openhatch.org/search/?q=&toughness=bitesize)
 * [CodeMontage](https://www.codemontage.com/)
-* [Open Source for Women](os4w.org)
+* [Open Source for Women](https://www.os4w.org)
 * [Github.com/Explore](https://github.com/explore)
 
 ## Suggestions by Language


### PR DESCRIPTION
Link was os4w.org, did not direct properly - needed https://www to direct correctly!
